### PR TITLE
Use Node 16 module resolution

### DIFF
--- a/docs/akte.app.ts
+++ b/docs/akte.app.ts
@@ -2,8 +2,8 @@ import { defineAkteApp } from "akte";
 
 import { version } from "../package.json";
 
-import { pages } from "./files/pages";
-import { sitemap } from "./files/sitemap";
+import { pages } from "./files/pages.js";
+import { sitemap } from "./files/sitemap.js";
 
 export const app = defineAkteApp({
 	files: [pages, sitemap],

--- a/docs/akte/markdownToHTML.ts
+++ b/docs/akte/markdownToHTML.ts
@@ -1,4 +1,4 @@
-import { type Plugin, type Processor, unified } from "unified";
+import { type Plugin, type Processor, unified, } from "unified";
 
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
@@ -10,15 +10,11 @@ import remarkRehype from "remark-rehype";
 
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
-import rehypeToc from "rehype-toc";
+import rehypeToc, { type Options as RehypeTocOptions } from "rehype-toc";
 import rehypeStringify from "rehype-stringify";
 
 import { common, createStarryNight } from "@wooorm/starry-night";
-
-// @ts-expect-error - Cannot resolve type
 import ignoreGrammar from "@wooorm/starry-night/source.gitignore";
-
-// @ts-expect-error - Cannot resolve type
 import tsxGrammar from "@wooorm/starry-night/source.tsx";
 import { visit } from "unist-util-visit";
 import { toString } from "hast-util-to-string";
@@ -177,7 +173,7 @@ export const markdownToHTML = async <TMatter extends Record<string, unknown>>(
 
 			.use(rehypeSlug)
 			.use(rehypeAutolinkHeadings, { behavior: "wrap" })
-			.use(rehypeToc, {
+			.use(rehypeToc as unknown as Plugin<[RehypeTocOptions]>, {
 				headings: ["h2", "h3"],
 				cssClasses: {
 					list: "",

--- a/docs/files/pages.ts
+++ b/docs/files/pages.ts
@@ -4,8 +4,8 @@ import * as fs from "node:fs/promises";
 import { defineAkteFiles } from "akte";
 import { globby } from "globby";
 
-import { markdownToHTML } from "../akte/markdownToHTML";
-import { base } from "../layouts/base";
+import { markdownToHTML } from "../akte/markdownToHTML.js";
+import { base } from "../layouts/base.js";
 
 const contentDir = path.resolve(__dirname, "../content");
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -3,17 +3,17 @@
 		"strict": true,
 		"skipLibCheck": true,
 
-		"target": "esnext",
-		"module": "esnext",
+		"target": "ES2022",
+		"module": "Node16",
 		"declaration": false,
-		"moduleResolution": "node",
+		"moduleResolution": "Node16",
 		"resolveJsonModule": true,
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
 
 		"forceConsistentCasingInFileNames": true,
 		"jsx": "preserve",
-		"lib": ["esnext", "dom"],
+		"lib": ["ES2023", "DOM"],
 		"types": ["node"]
 	},
 	"exclude": ["node_modules", "dist", "examples"]

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import akte from "akte/vite";
 
-import { app } from "./akte.app";
+import { app } from "./akte.app.js";
 
 export default defineConfig({
 	build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,10 +94,11 @@
 			}
 		},
 		"docs/node_modules/akte": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/akte/-/akte-0.4.0.tgz",
-			"integrity": "sha512-MjmEg8uKK2gGKgGM5cTkzf6lY3W2thROaZ/ivBd5a2NlsS0zhv4qCmkqEUMGjNr+Rd3atjoSLZkoPAZ9i/Yrzg==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/akte/-/akte-0.4.2.tgz",
+			"integrity": "sha512-9POFlm16Vigc3wgUu6KHzCCo0ojbdRQ377DL81vzhBObFN1CCDH71Tgn5AeZXvhuu+MpIZajjSbZQWeyOU1B+A==",
 			"dev": true,
+			"license": "MIT",
 			"workspaces": [
 				".",
 				"docs",
@@ -107,7 +108,7 @@
 			"dependencies": {
 				"debug": "^4.3.4",
 				"http-proxy": "^1.18.1",
-				"radix3": "^1.1.0"
+				"radix3": "^1.1.2"
 			},
 			"engines": {
 				"node": ">=16.13.0"

--- a/playground/akte.app.ts
+++ b/playground/akte.app.ts
@@ -1,9 +1,9 @@
 import { defineAkteApp } from "akte";
 
-import { index } from "./src/pages/index";
-import { sitemap } from "./src/pages/sitemap";
-import { postsSlug } from "./src/pages/posts/slug";
-import { catchAll } from "./src/pages/catchAll";
+import { index } from "./src/pages/index.js";
+import { sitemap } from "./src/pages/sitemap.js";
+import { postsSlug } from "./src/pages/posts/slug.js";
+import { catchAll } from "./src/pages/catchAll/index.js";
 
 export const app = defineAkteApp({
 	// files: [],

--- a/playground/src/pages/catchAll/index.ts
+++ b/playground/src/pages/catchAll/index.ts
@@ -1,7 +1,7 @@
 import { defineAkteFiles } from "akte";
-import { basic } from "../../layouts/basic";
+import { basic } from "../../layouts/basic.js";
 
-export const catchAll = defineAkteFiles().from({
+export const catchAll = defineAkteFiles<unknown>().from({
 	path: "/catch-all/**",
 	bulkData() {
 		return {

--- a/playground/src/pages/index.ts
+++ b/playground/src/pages/index.ts
@@ -1,7 +1,7 @@
 import { defineAkteFile } from "akte";
-import { basic } from "../layouts/basic";
+import { basic } from "../layouts/basic.js";
 
-export const index = defineAkteFile().from({
+export const index = defineAkteFile<unknown, number>().from({
 	path: "/",
 	async data() {
 		await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/playground/src/pages/posts/slug.ts
+++ b/playground/src/pages/posts/slug.ts
@@ -2,7 +2,7 @@ import { type PrismicDocument, createClient } from "@prismicio/client";
 import fetch from "node-fetch";
 
 import { defineAkteFiles } from "akte";
-import { basic } from "../../layouts/basic";
+import { basic } from "../../layouts/basic.js";
 
 const client = createClient("lihbr", {
 	routes: [

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import akte from "akte/vite";
 
-import { app } from "./akte.app";
+import { app } from "./akte.app.js";
 
 export default defineConfig({
 	root: "src",

--- a/src/AkteApp.ts
+++ b/src/AkteApp.ts
@@ -3,21 +3,21 @@ import { mkdir, writeFile } from "node:fs/promises";
 
 import { type MatchedRoute, type RadixRouter, createRouter } from "radix3";
 
-import type { AkteFiles } from "./AkteFiles";
-import type { Awaitable, GlobalDataFn } from "./types";
-import { NotFoundError } from "./errors";
-import { runCLI } from "./runCLI";
-import { akteWelcome } from "./akteWelcome";
+import type { AkteFiles } from "./AkteFiles.js";
+import type { Awaitable, GlobalDataFn } from "./types.js";
+import { NotFoundError } from "./errors.js";
+import { runCLI } from "./runCLI.js";
+import { akteWelcome } from "./akteWelcome.js";
 
-import { __PRODUCTION__ } from "./lib/__PRODUCTION__";
-import { createDebugger } from "./lib/createDebugger";
-import { pathToRouterPath } from "./lib/pathToRouterPath";
-import { isCLI } from "./lib/isCLI";
+import { __PRODUCTION__ } from "./lib/__PRODUCTION__.js";
+import { createDebugger } from "./lib/createDebugger.js";
+import { pathToRouterPath } from "./lib/pathToRouterPath.js";
+import { isCLI } from "./lib/isCLI.js";
 
 /* eslint-disable @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports */
 
-import type { defineAkteFile } from "./defineAkteFile";
-import type { defineAkteFiles } from "./defineAkteFiles";
+import type { defineAkteFile } from "./defineAkteFile.js";
+import type { defineAkteFiles } from "./defineAkteFiles.js";
 
 /* eslint-enable @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports */
 

--- a/src/AkteFiles.ts
+++ b/src/AkteFiles.ts
@@ -1,13 +1,13 @@
-import { NotFoundError } from "./errors";
-import { type Awaitable } from "./types";
+import { NotFoundError } from "./errors.js";
+import { type Awaitable } from "./types.js";
 
-import { createDebugger } from "./lib/createDebugger";
-import { pathToFilePath } from "./lib/pathToFilePath";
-import { toReadonlyMap } from "./lib/toReadonlyMap";
+import { createDebugger } from "./lib/createDebugger.js";
+import { pathToFilePath } from "./lib/pathToFilePath.js";
+import { toReadonlyMap } from "./lib/toReadonlyMap.js";
 
 /* eslint-disable @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports */
 
-import type { AkteApp } from "./AkteApp";
+import type { AkteApp } from "./AkteApp.js";
 
 /* eslint-enable @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports */
 

--- a/src/akteWelcome.ts
+++ b/src/akteWelcome.ts
@@ -2,9 +2,9 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { createRequire } from "node:module";
 
-import { __PRODUCTION__ } from "./lib/__PRODUCTION__";
-import { defineAkteFiles } from "./defineAkteFiles";
-import { NotFoundError } from "./errors";
+import { __PRODUCTION__ } from "./lib/__PRODUCTION__.js";
+import { defineAkteFiles } from "./defineAkteFiles.js";
+import { NotFoundError } from "./errors.js";
 
 /**
  * Akte welcome page shown in development when the Akte app does not have any

--- a/src/defineAkteApp.ts
+++ b/src/defineAkteApp.ts
@@ -1,4 +1,4 @@
-import { AkteApp, type Config } from "./AkteApp";
+import { AkteApp, type Config } from "./AkteApp.js";
 
 /**
  * Creates an Akte app from given configuration.

--- a/src/defineAkteFile.ts
+++ b/src/defineAkteFile.ts
@@ -3,8 +3,8 @@ import {
 	type FilesBulkDataFn,
 	type FilesDataFn,
 	type FilesDefinition,
-} from "./AkteFiles";
-import type { Empty } from "./types";
+} from "./AkteFiles.js";
+import type { Empty } from "./types.js";
 
 type FileDefinition<TGlobalData, TData> = Omit<
 	FilesDefinition<TGlobalData, never[], TData>,

--- a/src/defineAkteFiles.ts
+++ b/src/defineAkteFiles.ts
@@ -3,9 +3,9 @@ import {
 	type FilesBulkDataFn,
 	type FilesDataFn,
 	type FilesDefinition,
-} from "./AkteFiles";
+} from "./AkteFiles.js";
 
-import type { Empty } from "./types";
+import type { Empty } from "./types.js";
 
 /**
  * Creates an Akte files instance.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,20 +6,24 @@
 export class NotFoundError extends Error {
 	path: string;
 
+	// This property already exists on Error, but TypeScript is unaware
+	declare cause?: unknown;
+
 	constructor(
 		path: string,
 		options?: {
 			cause?: unknown;
 		},
 	) {
-		if (!options?.cause) {
-			super(`Could lookup file for path \`${path}\``, options);
-		} else {
-			super(
-				`Could lookup file for path \`${path}\`\n\n${options.cause.toString()}`,
-				options,
-			);
+		const cause = options?.cause;
+		let message = `Could lookup file for path \`${path}\``;
+
+		if (cause) {
+			message += `\n\n${cause.toString()}`;
 		}
+
+		// @ts-expect-error - TypeScript doesn't know Node 16 has the two argument Error constructor
+		super(message, options);
 
 		this.path = path;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-export type { Config, AkteApp } from "./AkteApp";
-export type { AkteFiles } from "./AkteFiles";
+export type { Config, AkteApp } from "./AkteApp.js";
+export type { AkteFiles } from "./AkteFiles.js";
 
-export { defineAkteApp } from "./defineAkteApp";
-export { defineAkteFile } from "./defineAkteFile";
-export { defineAkteFiles } from "./defineAkteFiles";
+export { defineAkteApp } from "./defineAkteApp.js";
+export { defineAkteFile } from "./defineAkteFile.js";
+export { defineAkteFiles } from "./defineAkteFiles.js";
 
-export { NotFoundError } from "./errors";
+export { NotFoundError } from "./errors.js";

--- a/src/lib/createDebugger.ts
+++ b/src/lib/createDebugger.ts
@@ -1,6 +1,6 @@
 import debug from "debug";
-import { hasHelp, hasSilent, hasVersion } from "./hasFlag";
-import { isCLI } from "./isCLI";
+import { hasHelp, hasSilent, hasVersion } from "./hasFlag.js";
+import { isCLI } from "./isCLI.js";
 
 type DebuggerFn = (msg: unknown, ...args: unknown[]) => void;
 type Debugger = DebuggerFn & {

--- a/src/lib/hasFlag.ts
+++ b/src/lib/hasFlag.ts
@@ -1,4 +1,4 @@
-import { commandsAndFlags } from "./commandsAndFlags";
+import { commandsAndFlags } from "./commandsAndFlags.js";
 
 const hasFlag = (...flags: string[]): boolean => {
 	for (const flag of flags) {

--- a/src/lib/pathToRouterPath.ts
+++ b/src/lib/pathToRouterPath.ts
@@ -1,4 +1,4 @@
-import { pathToFilePath } from "./pathToFilePath";
+import { pathToFilePath } from "./pathToFilePath.js";
 
 export const pathToRouterPath = (path: string): string => {
 	const filePath = pathToFilePath(path);

--- a/src/runCLI.ts
+++ b/src/runCLI.ts
@@ -1,9 +1,9 @@
-import { type AkteApp } from "./AkteApp";
+import { type AkteApp } from "./AkteApp.js";
 
-import { commandsAndFlags } from "./lib/commandsAndFlags";
-import { createDebugger } from "./lib/createDebugger";
-import { hasHelp, hasVersion } from "./lib/hasFlag";
-import { pkg } from "./lib/pkg";
+import { commandsAndFlags } from "./lib/commandsAndFlags.js";
+import { createDebugger } from "./lib/createDebugger.js";
+import { hasHelp, hasVersion } from "./lib/hasFlag.js";
+import { pkg } from "./lib/pkg.js";
 
 const debugCLI = createDebugger("akte:cli");
 

--- a/src/vite/AkteViteCache.ts
+++ b/src/vite/AkteViteCache.ts
@@ -1,9 +1,9 @@
 import { dirname, resolve } from "node:path";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 
-import type { AkteFiles } from "../AkteFiles";
-import { type Awaitable } from "../types";
-import { pathToFilePath } from "../lib/pathToFilePath";
+import type { AkteFiles } from "../AkteFiles.js";
+import { type Awaitable } from "../types.js";
+import { pathToFilePath } from "../lib/pathToFilePath.js";
 
 const GLOBAL_DATA = "app.globalData";
 const DATA = "file.data";

--- a/src/vite/aktePlugin.ts
+++ b/src/vite/aktePlugin.ts
@@ -1,9 +1,9 @@
 import { type PluginOption } from "vite";
 
-import { createDebugger } from "../lib/createDebugger";
-import { serverPlugin } from "./plugins/serverPlugin";
-import { buildPlugin } from "./plugins/buildPlugin";
-import type { Options, ResolvedOptions } from "./types";
+import { createDebugger } from "../lib/createDebugger.js";
+import { serverPlugin } from "./plugins/serverPlugin.js";
+import { buildPlugin } from "./plugins/buildPlugin.js";
+import type { Options, ResolvedOptions } from "./types.js";
 
 const MINIFY_HTML_DEFAULT_OPTIONS = {
 	collapseBooleanAttributes: true,

--- a/src/vite/createAkteViteCache.ts
+++ b/src/vite/createAkteViteCache.ts
@@ -1,4 +1,4 @@
-import { AkteViteCache } from "./AkteViteCache";
+import { AkteViteCache } from "./AkteViteCache.js";
 
 export const createAkteViteCache = (root: string): AkteViteCache => {
 	return new AkteViteCache(root);

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -1,4 +1,4 @@
-import { aktePlugin } from "./aktePlugin";
+import { aktePlugin } from "./aktePlugin.js";
 
 export default aktePlugin;
-export type { Options } from "./types";
+export type { Options } from "./types.js";

--- a/src/vite/plugins/buildPlugin.ts
+++ b/src/vite/plugins/buildPlugin.ts
@@ -5,10 +5,10 @@ import { existsSync } from "node:fs";
 
 import type { Plugin } from "vite";
 
-import type { ResolvedOptions } from "../types";
-import { createAkteViteCache } from "../createAkteViteCache";
-import { pkg } from "../../lib/pkg";
-import { createDebugger } from "../../lib/createDebugger";
+import type { ResolvedOptions } from "../types.js";
+import { createAkteViteCache } from "../createAkteViteCache.js";
+import { pkg } from "../../lib/pkg.js";
+import { createDebugger } from "../../lib/createDebugger.js";
 
 let isServerRestart = false;
 

--- a/src/vite/plugins/serverPlugin.ts
+++ b/src/vite/plugins/serverPlugin.ts
@@ -4,11 +4,11 @@ import { mkdir, writeFile } from "node:fs/promises";
 import type { Plugin } from "vite";
 import httpProxy from "http-proxy";
 
-import type { ResolvedOptions } from "../types";
-import { createAkteViteCache } from "../createAkteViteCache";
-import { NotFoundError } from "../../errors";
-import { pathToFilePath } from "../../lib/pathToFilePath";
-import { createDebugger } from "../../lib/createDebugger";
+import type { ResolvedOptions } from "../types.js";
+import { createAkteViteCache } from "../createAkteViteCache.js";
+import { NotFoundError } from "../../errors.js";
+import { pathToFilePath } from "../../lib/pathToFilePath.js";
+import { createDebugger } from "../../lib/createDebugger.js";
 
 const debug = createDebugger("akte:vite:server", true);
 

--- a/src/vite/types.ts
+++ b/src/vite/types.ts
@@ -1,6 +1,6 @@
 import type { Options as MinifyHTMLOptions } from "html-minifier-terser";
 
-import { type AkteApp } from "../AkteApp";
+import { type AkteApp } from "../AkteApp.js";
 
 /** Akte Vite plugin options. */
 export type Options<TGlobalData> = {

--- a/test/AkteApp-buildAll.test.ts
+++ b/test/AkteApp-buildAll.test.ts
@@ -2,13 +2,13 @@ import { posix } from "node:path";
 import { expect, it } from "vitest";
 import { vol } from "memfs";
 
-import { defineAkteApp } from "../src";
+import { defineAkteApp } from "../src/index.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
 
 it("builds all files at default output directory", async () => {
 	const app = defineAkteApp({

--- a/test/AkteApp-getGlobalData.test.ts
+++ b/test/AkteApp-getGlobalData.test.ts
@@ -1,12 +1,12 @@
 import { expect, it, vi } from "vitest";
 
-import { defineAkteApp } from "../src";
+import { defineAkteApp } from "../src/index.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
 
 it("caches global data", async () => {
 	const globalDataFn = vi.fn().mockImplementation(() => true);

--- a/test/AkteApp-getRouter.test.ts
+++ b/test/AkteApp-getRouter.test.ts
@@ -2,13 +2,13 @@ import { expect, it, vi } from "vitest";
 
 import { createRouter } from "radix3";
 
-import { defineAkteApp } from "../src";
+import { defineAkteApp } from "../src/index.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
 
 vi.mock("radix3", () => {
 	return {

--- a/test/AkteApp-lookup.test.ts
+++ b/test/AkteApp-lookup.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from "vitest";
 
-import { NotFoundError, defineAkteApp } from "../src";
+import { NotFoundError, defineAkteApp } from "../src/index.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
 
 const app = defineAkteApp({ files: [index, about, pages, posts, jsons] });
 

--- a/test/AkteApp-render.test.ts
+++ b/test/AkteApp-render.test.ts
@@ -1,13 +1,13 @@
 import { expect, it } from "vitest";
 
-import { NotFoundError, defineAkteApp } from "../src";
+import { NotFoundError, defineAkteApp } from "../src/index.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
-import { renderError } from "./__fixtures__/renderError";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
+import { renderError } from "./__fixtures__/renderError.js";
 
 const app = defineAkteApp({
 	files: [index, about, pages, posts, jsons, renderError],

--- a/test/AkteApp-renderAll.test.ts
+++ b/test/AkteApp-renderAll.test.ts
@@ -1,14 +1,14 @@
 import { expect, it, vi } from "vitest";
 
-import { defineAkteApp } from "../src";
+import { defineAkteApp } from "../src/index.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
-import { renderError } from "./__fixtures__/renderError";
-import { noGlobalData } from "./__fixtures__/noGlobalData";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
+import { renderError } from "./__fixtures__/renderError.js";
+import { noGlobalData } from "./__fixtures__/noGlobalData.js";
 
 it("renders all files", async () => {
 	const app = defineAkteApp({

--- a/test/AkteApp-writeAll.test.ts
+++ b/test/AkteApp-writeAll.test.ts
@@ -2,13 +2,13 @@ import { posix } from "node:path";
 import { expect, it, vi } from "vitest";
 import { vol } from "memfs";
 
-import { defineAkteApp } from "../src";
+import { defineAkteApp } from "../src/index.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
 
 it("writes all files at default output directory", async () => {
 	const app = defineAkteApp({

--- a/test/AkteFile-getBulkData.test.ts
+++ b/test/AkteFile-getBulkData.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, vi } from "vitest";
 
-import { defineAkteFile, defineAkteFiles } from "../src";
+import { defineAkteFile, defineAkteFiles } from "../src/index.js";
 
 it("caches bulk data", () => {
 	const bulkDataFn = vi.fn().mockImplementation(() => ({

--- a/test/AkteFile-getData.test.ts
+++ b/test/AkteFile-getData.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, vi } from "vitest";
 
-import { defineAkteFiles } from "../src";
+import { defineAkteFiles } from "../src/index.js";
 
 it("caches data", () => {
 	const dataFn = vi.fn().mockImplementation(() => true);

--- a/test/__fixtures__/about.ts
+++ b/test/__fixtures__/about.ts
@@ -1,4 +1,4 @@
-import { defineAkteFile } from "../../src";
+import { defineAkteFile } from "../../src/index.js";
 
 export const about = defineAkteFile().from({
 	path: "/about",

--- a/test/__fixtures__/index.ts
+++ b/test/__fixtures__/index.ts
@@ -1,4 +1,4 @@
-import { defineAkteFile } from "../../src";
+import { defineAkteFile } from "../../src/index.js";
 
 export const index = defineAkteFile().from({
 	path: "/",

--- a/test/__fixtures__/jsons.ts
+++ b/test/__fixtures__/jsons.ts
@@ -1,4 +1,4 @@
-import { defineAkteFiles } from "../../src";
+import { defineAkteFiles } from "../../src/index.js";
 
 export const jsons = defineAkteFiles().from({
 	path: "/:slug.json",

--- a/test/__fixtures__/noGlobalData.ts
+++ b/test/__fixtures__/noGlobalData.ts
@@ -1,4 +1,4 @@
-import { defineAkteFiles } from "../../src";
+import { defineAkteFiles } from "../../src/index.js";
 
 export const noGlobalData = defineAkteFiles().from({
 	path: "/no-global-data/:slug",

--- a/test/__fixtures__/pages.ts
+++ b/test/__fixtures__/pages.ts
@@ -1,4 +1,4 @@
-import { defineAkteFiles } from "../../src";
+import { defineAkteFiles } from "../../src/index.js";
 
 export const pages = defineAkteFiles().from({
 	path: "/pages/**",

--- a/test/__fixtures__/posts.ts
+++ b/test/__fixtures__/posts.ts
@@ -1,4 +1,4 @@
-import { defineAkteFiles } from "../../src";
+import { defineAkteFiles } from "../../src/index.js";
 
 export const posts = defineAkteFiles().from({
 	path: "/posts/:slug",

--- a/test/__fixtures__/renderError.ts
+++ b/test/__fixtures__/renderError.ts
@@ -1,4 +1,4 @@
-import { defineAkteFiles } from "../../src";
+import { defineAkteFiles } from "../../src/index.js";
 
 export const renderError = defineAkteFiles().from({
 	path: "/render-error/:slug",

--- a/test/defineAkteApp.test-d.ts
+++ b/test/defineAkteApp.test-d.ts
@@ -1,5 +1,5 @@
 import { it } from "vitest";
-import { defineAkteApp, defineAkteFiles } from "../src";
+import { defineAkteApp, defineAkteFiles } from "../src/index.js";
 
 const noGlobalData = defineAkteFiles().from({
 	path: "/:slug",

--- a/test/defineAkteFile.test-d.ts
+++ b/test/defineAkteFile.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf, it } from "vitest";
-import { defineAkteFile } from "../src";
+import { defineAkteFile } from "../src/index.js";
 
 it("infers data from data", () => {
 	defineAkteFile().from({

--- a/test/defineAkteFiles.test-d.ts
+++ b/test/defineAkteFiles.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf, it } from "vitest";
-import { defineAkteFiles } from "../src";
+import { defineAkteFiles } from "../src/index.js";
 
 it("infers data from data", () => {
 	defineAkteFiles().from({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest";
 
-import * as lib from "../src";
+import * as lib from "../src/index.js";
 
 // TODO: Dummy test, meant to be removed when real tests come in
 it("exports something", () => {

--- a/test/runCLI.test.ts
+++ b/test/runCLI.test.ts
@@ -1,14 +1,14 @@
 import { expect, it, vi } from "vitest";
 import { vol } from "memfs";
 
-import { defineAkteApp } from "../src";
-import { runCLI } from "../src/runCLI";
+import { defineAkteApp } from "../src/index.js";
+import { runCLI } from "../src/runCLI.js";
 
-import { index } from "./__fixtures__";
-import { about } from "./__fixtures__/about";
-import { pages } from "./__fixtures__/pages";
-import { posts } from "./__fixtures__/posts";
-import { jsons } from "./__fixtures__/jsons";
+import { index } from "./__fixtures__/index.js";
+import { about } from "./__fixtures__/about.js";
+import { pages } from "./__fixtures__/pages.js";
+import { posts } from "./__fixtures__/posts.js";
+import { jsons } from "./__fixtures__/jsons.js";
 
 it("builds product upon build command", async () => {
 	const app = defineAkteApp({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,17 +3,17 @@
 		"strict": true,
 		"skipLibCheck": true,
 
-		"target": "esnext",
-		"module": "esnext",
+		"target": "ES2021",
+		"module": "Node16",
 		"declaration": false,
-		"moduleResolution": "node",
+		"moduleResolution": "Node16",
 		"resolveJsonModule": true,
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
 
 		"forceConsistentCasingInFileNames": true,
 		"jsx": "preserve",
-		"lib": ["esnext", "dom"],
+		"lib": ["ES2021", "DOM"],
 		"types": ["node"]
 	},
 	"exclude": ["node_modules", "dist", "examples"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vite";
 import sdk from "vite-plugin-sdk";
 import { minify } from "html-minifier-terser";
 
-import { app } from "./docs/akte.app";
+import { app } from "./docs/akte.app.js";
 
 const MINIFY_HTML_OPTIONS = {
 	collapseBooleanAttributes: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

What I changed:
- Changed `tsconfig.json` target, package, etc fields to appropriate values for Node 16 [as per the official documentation](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping).
- Updated import statements to include explicit `.js` extension where appropriate. This also means no more implicit index.js imports. :horse:
- Added `cause` property declaration to `NotFoundError` and changed the constructor code a little to make TypeScript happy. This part is slightly annoying, because Node 16 is ES2021 according to the above docs, but it also has `Error.cause` and the two argument Error constructor from ES2022 since v16.9.0. TypeScript doesn't account for that, so I had to smack it with a wrench to get it working.

As for why—`"node"` for tsconfig's `module` and `moduleResolution` is deprecated in favor of `"node16"`. Akte is currently incompatible with projects that use that setting. This PR fixes that, and you'll now get type errors if you try to use language features that aren't supported on Node 16 as an added bonus.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
